### PR TITLE
Decode TXT record byte literal.

### DIFF
--- a/hook.py
+++ b/hook.py
@@ -76,6 +76,7 @@ def _has_dns_propagated(name, token):
         return False
 
     for txt_record in txt_records:
+        txt_record=txt_record.decode()
         if txt_record == token:
             return True
 


### PR DESCRIPTION
With some debug statements added, this is what's happening:

```
Checking _acme-challenge.X.Y for token jYMIkcfuFDbtoEAjzwwpbrYewPlG1u9gxJf-FsNHq3c
Got TXT records: [b'jYMIkcfuFDbtoEAjzwwpbrYewPlG1u9gxJf-FsNHq3c']
 + DNS not propagated, waiting 30s...
```

Token is never matched, because `txt_record` from DNSMadeEasy API is a byte literal but token is a regular python string.

I'm not a Python developer, so if a nicer solution exists, please suggest it.
