### PR TITLE
Add exit_hook

### DIFF
--- a/hook.py
+++ b/hook.py
@@ -161,7 +161,7 @@ def deploy_cert(args):
     logger.info(' + ssl_certificate_key: {0}'.format(privkey_pem))
     return
 
-def unchanged_cert(args):
+def do_nothing(args):
     return
 
 def main(argv):
@@ -169,7 +169,8 @@ def main(argv):
         'deploy_challenge': create_txt_record,
         'clean_challenge' : delete_txt_record,
         'deploy_cert'     : deploy_cert,
-        'unchanged_cert'  : unchanged_cert,
+        'unchanged_cert'  : do_nothing,
+        'exit_hook'       : do_nothing,
     }
     logger.info(" + dnsmadeeasy hook executing: {0}".format(argv[0]))
     ops[argv[0]](argv[1:])


### PR DESCRIPTION
dehydrated (formerly letsencrypt.sh) added the exit_hook earlier this year, this is to prevent script from raising KeyError for an expected hook.