### PR TITLE
decode rdata.strings from byte type

### DIFF
--- a/hook.py
+++ b/hook.py
@@ -71,7 +71,7 @@ def _has_dns_propagated(name, token):
             dns_response = dns.resolver.query(name, 'TXT')
         for rdata in dns_response:
             for txt_record in rdata.strings:
-                txt_records.append(txt_record)
+                txt_records.append(txt_record.decode())
     except dns.exception.DNSException as error:
         return False
 


### PR DESCRIPTION
The script broke after the update from Debian 8 to Debian 9. (with python3-dnspython 1.25.0-1)  
rdata.strings returned byte type strings which did not match the token due to different encoding.