### PR TITLE
convert token to bytearray when comparing with TXT records

### DIFF
--- a/hook.py
+++ b/hook.py
@@ -81,7 +81,7 @@ def _has_dns_propagated(name, token):
         return False
 
     for txt_record in txt_records:
-        if txt_record == token:
+        if txt_record == bytearray(token, 'ascii'):
             return True
 
     return False


### PR DESCRIPTION
It failed to match without this on python 2.7